### PR TITLE
chore(example-app): update missing variables

### DIFF
--- a/example-app/android/variables.gradle
+++ b/example-app/android/variables.gradle
@@ -13,6 +13,6 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
-    androidxExifInterfaceVersion='1.3.7'
-    androidxMaterialVersion='1.8.0'
+    androidxExifInterfaceVersion = '1.4.1'
+    androidxMaterialVersion = '1.13.0'
 }


### PR DESCRIPTION
the `npx cap migrate` command didn't update them because of the missing whitespaces