### PR TITLE
fix(android): replace proguard-android.txt with proguard-android-optimize.txt for AGP 9 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
AGP 9 removed support for `proguard-android.txt`, which causes Android builds to fail for projects using AGP 9+.

```
.../node_modules/@capacitor-community/file-opener/android/build.gradle' line: 33
[10:07:17]: ▸ * What went wrong:
[10:07:17]: ▸ A problem occurred evaluating project ':capacitor-community-file-opener'.
[10:07:17]: ▸ > getDefaultProguardFile('proguard-android.txt') is no longer supported since it includes -dontoptimize, which prevents R8 from performing many optimizations. Instead use getDefaultProguardFile('proguard-android-optimize.txt), and if needed, temporarily use -dontoptimize in a custom keep rule file while fixing breakages.
```

This change replaces it with `proguard-android-optimize.txt`, which is the recommended default ProGuard file.

This fixed the issue in my Capacitor app after upgrading the Android/Gradle setup.


Before:
getDefaultProguardFile('proguard-android.txt')

After:
getDefaultProguardFile('proguard-android-optimize.txt')