### PR TITLE
chore: release file-opener 8.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v8.0.1](https://github.com/capacitor-community/file-opener/compare/v8.0.0...v8.0.1) (2026-05-29)
+
+### Enhancements
+
+- replace Android default ProGuard file with `proguard-android-optimize.txt` for AGP 9 compatibility ([#87](https://github.com/capacitor-community/file-opener/pull/87))
+
+### Chores
+
+- bumped **example-app** to v8.0.1
+- updated **example-app** Android build to AGP 9.2.1 and Gradle 9.4.1
+
 ## [v8.0.0](https://github.com/capacitor-community/file-opener/compare/v7.0.1...v8.0.0) (2025-12-25)
 
 ### Chores

--- a/example-app/android/app/build.gradle
+++ b/example-app/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/example-app/android/build.gradle
+++ b/example-app/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.2.1'
         classpath 'com.google.gms:google-services:4.4.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/example-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "example-app",
-  "version": "7.0.1",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example-app",
-      "version": "7.0.1",
+      "version": "8.0.1",
       "dependencies": {
         "@angular/animations": "^19.1.3",
         "@angular/common": "^19.1.3",
@@ -62,7 +62,7 @@
     },
     "..": {
       "name": "@capacitor-community/file-opener",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-app",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": "Alex Ryltsov <ryltsov.alex@gmail.com>",
   "homepage": "https://github.com/capacitor-community/file-opener",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@capacitor-community/file-opener",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capacitor-community/file-opener",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor-community/file-opener",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Capacitor File Opener. The plugin is able to open a file given the mimeType and the file uri.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Changes:
- Bump package version to 8.0.1
- Update example app version to 8.0.1
- Update example app Android build to AGP 9.2.1 and Gradle 9.4.1
- Replace example app default ProGuard file with proguard-android-optimize.txt
- Add v8.0.1 changelog entry for AGP 9 compatibility
- Update package lock files